### PR TITLE
Remove unathorized user from edit post of a searched profile

### DIFF
--- a/frontend/src/Components/HomePage/helperComponents/UserDetails.jsx
+++ b/frontend/src/Components/HomePage/helperComponents/UserDetails.jsx
@@ -210,6 +210,7 @@ export const UserDetails = ({ searchedProfileId, setSearchedProfileId }) => {
                   setLoadingstate={setLoadingstate}
                   key={post._id}
                   postId={post._id}
+                  postUserId={post.userId._id}
                   username={post.userId.username}
                   fullname={post.userId.fullname}
                   content={post.content}


### PR DESCRIPTION
I included the postUserId to the UserDetails, to ensure that if the postUserId is not equals present user's id, the edit and delete icon won't be displayed.